### PR TITLE
Include types in exports

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -15,7 +15,8 @@
         ".": {
             "import": "./dist/<%= name %>.js",
             "require": "./dist/<%= name %>.cjs",
-            "default": "./dist/<%= name %>.js"
+            "default": "./dist/<%= name %>.js",
+            "types": "./dist/<%= name %>.d.ts"
         },
         "./<%= name %>.css": {
             "import": "./dist/<%= name %>.css"


### PR DESCRIPTION
## Summary

Adds types (`object.d.ts`) to package exports, allowing the package to be used as a dependency in other typescript projects

## Testing

1. Create a test project based on this template.
    - package.json should include `types: "project-name.d.ts"` in its export list